### PR TITLE
Docker issue fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,9 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /myapp
 
 # Update system and specifically upgrade libc-bin to the required security patch version
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc \
-    libpq-dev \
-    && apt-get install -y libc-bin=2.36-9+deb12u7 \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libpq-dev \
+    && apt-get install -y --allow-downgrades libc-bin=2.36-9+deb12u7 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -30,7 +29,7 @@ RUN python -m venv /.venv \
 FROM python:3.12-slim-bookworm as final
 
 # Upgrade libc-bin in the final stage to ensure security patch is applied
-RUN apt-get update && apt-get install -y libc-bin=2.36-9+deb12u7 \
+RUN apt-get update && apt-get install -y --allow-downgrades libc-bin=2.36-9+deb12u7 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes #1 

Root Cause:
Debian’s apt-get does not allow package downgrades with the -y flag unless --allow-downgrades is explicitly provided.

Fix Implemented:
The Dockerfile was updated to include the --allow-downgrades flag during the apt-get install step for libc-bin. This ensures the desired version can be installed without breaking the build.

Fix Code Snippet (Dockerfile):

dockerfile
Copy
Edit
RUN apt-get update \
    && apt-get install -y --no-install-recommends gcc libpq-dev \
    && apt-get install -y --allow-downgrades libc-bin=2.36-9+deb12u7 \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/*
Status: ✅ Fixed

Impact:
The Docker image now builds successfully without error, making it possible to deploy the FastAPI backend in a containerized environment.