### PR TITLE
unique violation error for email and nickname issue

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,13 +162,14 @@ async def unverified_user(db_session):
 
 @pytest.fixture(scope="function")
 async def users_with_same_role_50_users(db_session):
+    fake.unique.clear()  # Clear the uniqueness tracker in case of reuse
     users = []
     for _ in range(50):
         user_data = {
-            "nickname": fake.user_name(),
+            "nickname": fake.unique.user_name(),
             "first_name": fake.first_name(),
             "last_name": fake.last_name(),
-            "email": fake.email(),
+            "email": fake.unique.email(),  
             "hashed_password": fake.password(),
             "role": UserRole.AUTHENTICATED,
             "email_verified": False,


### PR DESCRIPTION
🛠️ Fix
Use the .unique proxy provided by Faker to ensure all generated values for nickname and email are unique.