### PR TITLE
profile pic upload using minio image storage

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -22,6 +22,7 @@ from builtins import dict, int, len, str
 from datetime import timedelta
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Response, status, Request
+from fastapi import File, UploadFile
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_current_user, get_db, get_email_service, require_role
@@ -30,6 +31,7 @@ from app.schemas.token_schema import TokenResponse
 from app.schemas.user_schemas import LoginRequest, UserBase, UserCreate, UserListResponse, UserResponse, UserUpdate
 from app.services.user_service import UserService
 from app.services.jwt_service import create_access_token
+from app.utils.image_uploader import MAX_FILE_SIZE, allowed_file, upload
 from app.utils.link_generation import create_user_links, generate_pagination_links
 from app.dependencies import get_settings
 from app.services.email_service import EmailService
@@ -245,3 +247,35 @@ async def verify_email(user_id: UUID, token: str, db: AsyncSession = Depends(get
     if await UserService.verify_email_with_token(db, user_id, token):
         return {"message": "Email verified successfully"}
     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification token")
+
+@router.put("/upload/{user_id}",response_model=UserResponse, status_code=status.HTTP_202_ACCEPTED, name="update_image", tags=["User Management Requires (Admin or Manager Roles)"])
+async def update_image(user_id: UUID, request: Request,db: AsyncSession = Depends(get_db), token: str = Depends(oauth2_scheme), current_user: dict = Depends(require_role(["ADMIN", "MANAGER"])),file:UploadFile=File(...)):
+    """
+    Update user information.
+    - **user_id**: UUID of the user to update.
+    - **user_update**: UserUpdate model with updated user information.
+    """
+    if not allowed_file(file):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Select an Image with '.png', '.jpg', '.jpeg' extension")
+    if file.size > MAX_FILE_SIZE:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File Size too big")
+    image_url = await upload(file,user_id)
+    updated_user = await UserService.upload(db,user_id, {"profile_picture_url" : image_url})
+    if not updated_user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return UserResponse.model_construct(
+        id=updated_user.id,
+        bio=updated_user.bio,
+        first_name=updated_user.first_name,
+        last_name=updated_user.last_name,
+        nickname=updated_user.nickname,
+        email=updated_user.email,
+        role=updated_user.role,
+        last_login_at=updated_user.last_login_at,
+        profile_picture_url=updated_user.profile_picture_url,
+        github_profile_url=updated_user.github_profile_url,
+        linkedin_profile_url=updated_user.linkedin_profile_url,
+        created_at=updated_user.created_at,
+        updated_at=updated_user.updated_at,
+        links=create_user_links(updated_user.id, request)
+    )

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -199,3 +199,23 @@ class UserService:
             await session.commit()
             return True
         return False
+
+
+    @classmethod
+    async def upload(cls, session: AsyncSession, user_id: UUID, profile_image: Dict[str, str]) -> Optional[User]:
+        try:
+            # validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
+            validated_data = UserUpdate(**profile_image).model_dump(exclude_unset=True)
+            query = update(User).where(User.id == user_id).values(**validated_data).execution_options(synchronize_session="fetch")
+            await cls._execute_query(session, query)
+            updated_user = await cls.get_by_id(session, user_id)
+            if updated_user:
+                await session.refresh(updated_user)  # Explicitly refresh the updated user object
+                logger.info(f"User {user_id} updated successfully.")
+                return updated_user
+            else:
+                logger.error(f"User {user_id} not found after update attempt.")
+            return None
+        except Exception as e:  # Broad exception handling for debugging
+            logger.error(f"Error during user update: {e}")
+            return None

--- a/app/utils/image_uploader.py
+++ b/app/utils/image_uploader.py
@@ -1,0 +1,53 @@
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from minio import Minio
+from minio.error import S3Error
+import os
+from builtins import str
+from uuid import UUID
+from settings.config import settings
+from PIL import Image
+from io import BytesIO
+minio_client = Minio(
+    settings.MINIO_ENDPOINT,
+    access_key=settings.MINIO_ACCESS_KEY,
+    secret_key=settings.MINIO_SECRET_KEY,
+    secure=False
+)
+ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg'}
+MAX_FILE_SIZE = 10 * 1024 * 1024 
+async def upload(file : UploadFile,user_id:UUID) -> str:
+    try:
+            # Save the uploaded file to a temporary directory
+        # p = read_index()
+        
+        file_path = f"/tmp/{file.filename}"
+        size = (200, 200)  # New size: width = 200, height = 200
+        with open(file_path, "wb") as buffer:
+            buffer.write(await file.read())
+        resized_image_data = resize_image(file_path, size,user_id)
+        print(resized_image_data)
+        
+        image_name = str(user_id)+"."+file.filename.split('.')[1]
+        # Upload the file to Minio
+        minio_client.fput_object(settings.MINIO_BUCKET_NAME, image_name, resized_image_data)
+        # Remove the temporary file
+        os.remove(file_path)
+        os.remove(resized_image_data)
+        # Return success response
+        return "http://localhost:9000/"+settings.MINIO_BUCKET_NAME+"/"+image_name
+    except S3Error as exc:
+        print("error occurred.", exc)
+        return None
+def allowed_file(file:UploadFile):
+    filename = file.filename
+    """Check if the file has allowed extension"""
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+def resize_image(image, size,user_id):
+    with Image.open(image) as img:
+        resized_img = img.resize(size)
+        # Convert image to bytes
+        output_path = f"/tmp/{str(user_id)+"."+image.split('.')[1]}"
+        resized_img.save(output_path)
+        return output_path

--- a/app/utils/image_uploader.py
+++ b/app/utils/image_uploader.py
@@ -44,10 +44,10 @@ def allowed_file(file:UploadFile):
     filename = file.filename
     """Check if the file has allowed extension"""
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
-def resize_image(image, size,user_id):
+def resize_image(image, size, user_id):
     with Image.open(image) as img:
         resized_img = img.resize(size)
-        # Convert image to bytes
-        output_path = f"/tmp/{str(user_id)+"."+image.split('.')[1]}"
+        ext = image.split('.')[-1]  # safer than [1]
+        output_path = f"/tmp/{str(user_id)}.{ext}"
         resized_img.save(output_path)
         return output_path

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,26 @@ services:
     networks:
       - app-network
 
+  minio:
+     image: minio/minio
+     container_name: minio
+     ports:
+       - "9000:9000"
+       - "9001:9001"
+     volumes:
+       - minio_data:/data
+     environment:
+       MINIO_ROOT_USER: minioadmin
+       MINIO_ROOT_PASSWORD: miniopassword
+     command: server /data --console-address ":9001"
+     healthcheck:
+       test: ["CMD", "curl", "-f", "http://localhost:9001"]
+       interval: 30s
+       timeout: 20s
+       retries: 3
+     networks:
+       - app-network
+
   pgadmin:
     image: dpage/pgadmin4
     environment:
@@ -54,6 +74,7 @@ services:
 volumes:
   postgres-data:
   pgadmin-data:
+  minio_data:
 
 networks:
   app-network:

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,3 +61,5 @@ uvicorn==0.29.0
 validators==0.24.0
 markdown2
 pyjwt
+Pillow
+minio==7.2.7

--- a/settings/config.py
+++ b/settings/config.py
@@ -40,6 +40,11 @@ class Settings(BaseSettings):
     smtp_port: int = Field(default=2525, description="SMTP port for sending emails")
     smtp_username: str = Field(default='your-mailtrap-username', description="Username for SMTP server")
     smtp_password: str = Field(default='your-mailtrap-password', description="Password for SMTP server")
+    #Image Storage for Minio
+    MINIO_ENDPOINT : str = Field(default='your-minio-endpoint', description="Endpoint for minio")
+    MINIO_ACCESS_KEY : str = Field(default='yout-minio-access-key', description="Access Key for minio")
+    MINIO_SECRET_KEY : str = Field(default='yout-minio-secret-key', description="Secret Key for minio")
+    MINIO_BUCKET_NAME : str = Field(default='your-minio-bucket-name', description="Bucket Name for minio")
 
 
     class Config:

--- a/tests/test_image_uploader.py
+++ b/tests/test_image_uploader.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+from app.utils.image_uploader import upload, allowed_file, resize_image
+from minio.error import S3Error
+from uuid import uuid4
+from fastapi import UploadFile
+from PIL import Image
+from io import BytesIO
+from unittest.mock import patch, mock_open, MagicMock, call
+from app.dependencies import get_settings
+settings = get_settings()
+
+@pytest.fixture
+def test_image():
+    # Create a test image
+    image = Image.new('RGB', (500, 300), color='red')
+    image.save('/tmp/test_image.jpg')
+    return '/tmp/test_image.jpg'
+
+@pytest.fixture
+def test_file():
+    image = Image.new('RGB', (500, 300), color='red')
+    image.save('/tmp/test_image.jpg')
+    return UploadFile(filename="test_image.jpg", file=BytesIO(image.tobytes()))
+
+@pytest.fixture
+def test_user_id():
+    return uuid4()
+def test_allowed_file():
+    file_data = b"image_data"
+    assert allowed_file(UploadFile(filename="image.png", file=file_data))
+    assert allowed_file(UploadFile(filename="image.jpg", file=file_data))
+    assert allowed_file(UploadFile(filename="image.jpeg", file=file_data))
+    # Test disallowed file extensions
+    assert not allowed_file(UploadFile(filename="image.txt", file=file_data))
+    assert not allowed_file(UploadFile(filename="image.gif", file=file_data))
+def test_resize_image(test_image, test_user_id):
+    resized_image_path = resize_image(test_image, (200, 200), test_user_id)
+    assert os.path.exists(resized_image_path)
+    assert resized_image_path == f"/tmp/{str(test_user_id)}.jpg"
+    os.remove(test_image)
+    os.remove(resized_image_path)
+
+@patch("PIL.Image.open")
+@patch("app.utils.image_uploader.minio_client.fput_object")
+async def test_upload_error(mock_fput_object, mock_image_open, test_file, test_user_id):
+    mock_image = MagicMock(spec=Image.Image)
+    mock_image.resize.return_value = mock_image
+    mock_image_open.return_value = mock_image
+    with patch("builtins.open", mock_open(read_data=b"test image data")), \
+        patch("app.utils.image_uploader.resize_image", return_value="/tmp/resized_test.jpg"), \
+        patch("app.utils.image_uploader.minio_client.fput_object", side_effect=S3Error(code=500, message="S3 error", resource="bucket/object", request_id="request_id", host_id="host_id",response="response")):
+        url = await upload(test_file, test_user_id)
+        assert url is None
+
+@patch("PIL.Image.open")
+@patch("app.utils.image_uploader.minio_client.fput_object")
+@patch("os.remove")  # Mock os.remove
+async def test_upload(mock_os_remove, mock_fput_object, mock_image_open, test_file, test_user_id):
+    mock_image = MagicMock(spec=Image.Image)
+    mock_image.resize.return_value = mock_image
+    mock_image_open.return_value = mock_image
+
+    with patch("builtins.open", mock_open(read_data=b"test image data")), \
+        patch("app.utils.image_uploader.resize_image", return_value="/tmp/resized_test.jpg"):
+        url = await upload(test_file, test_user_id)
+
+        assert url == f"http://localhost:9000/{settings.MINIO_BUCKET_NAME}/{str(test_user_id)}.jpg"
+        mock_fput_object.assert_called_with(settings.MINIO_BUCKET_NAME, f"{str(test_user_id)}.jpg", "/tmp/resized_test.jpg")
+        
+        # Correctly check both os.remove calls
+        mock_os_remove.assert_has_calls([
+            call("/tmp/test_image.jpg"),  # Use 'call' here
+            call("/tmp/resized_test.jpg")
+        ], any_order=True)


### PR DESCRIPTION
Feature | Description
-- | --
Upload API | PUT /upload/{user_id} API endpoint to upload profile pictures
Validation | Accepts only .jpg, .jpeg, .png files under 10MB
Image Resizing | Resizes the image to 200x200 pixels before upload
MinIO Integration | Stores resized images in a MinIO object storage bucket
Profile Update | Updates the profile_picture_url field in the user profile
Public Access URL | Returns a public URL for the uploaded image


Fixes #15 